### PR TITLE
implement seed reproducibility check and pytest

### DIFF
--- a/dream_layer_backend/dream_layer.py
+++ b/dream_layer_backend/dream_layer.py
@@ -9,9 +9,12 @@ from flask_cors import CORS
 import requests
 import json
 import subprocess
+import hashlib
 from dream_layer_backend_utils.random_prompt_generator import fetch_positive_prompt, fetch_negative_prompt
 from dream_layer_backend_utils.fetch_advanced_models import get_lora_models, get_settings, is_valid_directory, get_upscaler_models, get_controlnet_models
 from dream_layer_backend_utils.random_prompt_generator import fetch_positive_prompt, fetch_negative_prompt
+from dream_layer_backend_utils.workflow_execution import execute_workflow
+
 # Add ComfyUI directory to Python path
 current_dir = os.path.dirname(os.path.abspath(__file__))
 parent_dir = os.path.dirname(current_dir)
@@ -482,6 +485,36 @@ def get_controlnet_models_endpoint():
             "status": "error",
             "message": f"Failed to fetch ControlNet models: {str(e)}"
         }), 500
+    
+@app.route('/debug/reproduce', methods=['GET'])
+def debug_reproduce():
+    last_job_path = os.path.expanduser('~/jobs/last.json')
+
+    if not os.path.exists(last_job_path):
+        return jsonify({"error": "No last job found"}), 404
+
+    with open(last_job_path, 'r') as f:
+        job_data = json.load(f)
+
+    original_output_path = job_data.get('output_path')
+
+    if not os.path.exists(original_output_path):
+        return jsonify({"error": "Original output not found"}), 404
+
+    # Compute hash of the original output
+    with open(original_output_path, 'rb') as original_file:
+        original_hash = hashlib.sha256(original_file.read()).hexdigest()
+
+    # Re-run the job
+    execute_workflow(job_data['workflow'])
+
+    # Compute hash of the new output
+    with open(original_output_path, 'rb') as new_file:
+        new_hash = hashlib.sha256(new_file.read()).hexdigest()
+
+    match = original_hash == new_hash
+
+    return jsonify({"match": match})
 
 if __name__ == "__main__":
     print("Starting Dream Layer backend services...")

--- a/dream_layer_backend/dream_layer_backend_utils/workflow_execution.py
+++ b/dream_layer_backend/dream_layer_backend_utils/workflow_execution.py
@@ -20,3 +20,16 @@ def interrupt_workflow():
     except Exception as e:
         logger.error(f"Error interrupting workflow: {str(e)}")
         return False 
+    
+def execute_workflow(workflow):
+    """
+    Execute a workflow via ComfyUI API
+    """
+    try:
+        response = requests.post(f"{COMFY_API_URL}/prompt", json=workflow)
+        response.raise_for_status()
+        logger.info("Workflow execution request sent successfully.")
+        return response.json()
+    except requests.RequestException as e:
+        logger.error(f"Workflow execution request failed: {str(e)}")
+        return None

--- a/dream_layer_backend/tests/conftest.py
+++ b/dream_layer_backend/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from dream_layer import app
+
+@pytest.fixture
+def client():
+    with app.test_client() as client:
+        yield client

--- a/dream_layer_backend/tests/test_debug_reproduce.py
+++ b/dream_layer_backend/tests/test_debug_reproduce.py
@@ -1,0 +1,42 @@
+import json
+import os
+from unittest.mock import patch, MagicMock
+
+def test_debug_reproduce(client, tmp_path):
+    dummy_job = {
+        "workflow": {"dummy": "data"},
+        "output_path": str(tmp_path / "output.png")
+    }
+
+    os.makedirs(os.path.expanduser('~/jobs'), exist_ok=True)
+    last_job_path = os.path.expanduser('~/jobs/last.json')
+
+    # Write original content clearly
+    with open(dummy_job['output_path'], 'wb') as f:
+        f.write(b'original content')
+
+    # Save the last job data
+    with open(last_job_path, 'w') as f:
+        json.dump(dummy_job, f)
+
+    # Define a side effect function for mocking requests.post
+    def mock_requests_post(*args, **kwargs):
+        # Clearly simulate successful ComfyUI workflow execution
+        with open(dummy_job['output_path'], 'wb') as f:
+            f.write(b'original content')  # Restore original content clearly
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"status": "success"}
+        return mock_response
+
+    # Mutate file content clearly before calling the endpoint
+    with open(dummy_job['output_path'], 'wb') as f:
+        f.write(b'mutated content')
+
+    # Mock 'requests.post' directly to prevent real HTTP calls
+    with patch('requests.post', side_effect=mock_requests_post):
+
+        response = client.get('/debug/reproduce')
+
+        assert response.status_code == 200
+        assert response.get_json() == {"match": False}


### PR DESCRIPTION
adds a /debug/reproduce api endpoint to check reproducibility by re-running the last job and comparing SHA256 hashes of outputs. includes pytest that verifies endpoint behavior