### PR TITLE
Add luma_img2img node for Luma image modification API

### DIFF
--- a/nodes/api_nodes/luma_img2img.py
+++ b/nodes/api_nodes/luma_img2img.py
@@ -1,0 +1,96 @@
+import os
+import requests
+from PIL import Image
+from io import BytesIO
+from typing import Optional
+
+import numpy as np
+
+# These are placeholders for how ComfyUI might structure utilities
+# If your project uses a different image tensor helper, update accordingly
+def tensor_to_image(tensor: np.ndarray) -> Image.Image:
+    """Converts a 3xHxW tensor to a PIL image (RGB)."""
+    tensor = np.clip(tensor * 255, 0, 255).astype(np.uint8)
+    return Image.fromarray(np.transpose(tensor, (1, 2, 0)))
+
+
+def image_to_tensor(image: Image.Image) -> np.ndarray:
+    """Converts a PIL image to a 3xHxW float32 tensor scaled [0, 1]."""
+    image = image.convert("RGB")
+    arr = np.array(image).astype(np.float32) / 255.0
+    return np.transpose(arr, (2, 0, 1))
+
+
+class ComfyUIWarning(Exception):
+    pass
+
+
+class LumaImg2Img:
+    """
+    Luma Image-to-Image Node
+
+    This node modifies an input image using the Luma API.
+
+    Required env:
+        LUMA_API_KEY (str) — your API key from Luma
+
+    Inputs:
+        image (Tensor) — input image tensor
+        prompt (str) — prompt to guide the image generation
+
+    Optional:
+        image_weight (float) — [0.02, 1.0], default=0.5
+        model (str) — default="luma-v3"
+        aspect_ratio (str) — "1:1", "16:9", etc. Default: "1:1"
+        seed (int) — random seed for reproducibility
+        timeout (float) — request timeout in seconds
+
+    Output:
+        modified_image (Tensor) — the returned image
+    """
+    def run(
+        self,
+        image,
+        prompt: str,
+        image_weight: float = 0.5,
+        model: str = "luma-v3",
+        aspect_ratio: str = "1:1",
+        seed: Optional[int] = None,
+        timeout: float = 30.0,
+    ):
+        api_key = os.getenv("LUMA_API_KEY")
+        if not api_key:
+            raise ComfyUIWarning("Missing $LUMA_API_KEY — set this in your environment or ~/.dreamlayer/keys.toml")
+
+        # Convert image tensor to PNG byte stream
+        pil_img = tensor_to_image(image)
+        buffer = BytesIO()
+        pil_img.save(buffer, format="PNG")
+        buffer.seek(0)
+
+        payload = {
+            "prompt": prompt,
+            "image_weight": image_weight,
+            "model": model,
+            "aspect_ratio": aspect_ratio,
+        }
+
+        if seed is not None:
+            payload["seed"] = seed
+
+        files = {"image": ("image.png", buffer, "image/png")}
+        headers = {"Authorization": f"Bearer {api_key}"}
+
+        response = requests.post(
+            "https://api.luma.ai/proxy/luma/generations/image",
+            headers=headers,
+            data=payload,
+            files=files,
+            timeout=timeout
+        )
+
+        if not response.ok:
+            raise RuntimeError(f"Luma API failed: {response.status_code} {response.text}")
+
+        result_image = Image.open(BytesIO(response.content)).convert("RGB")
+        return {"image": image_to_tensor(result_image)}

--- a/tests/api_nodes/test_luma_img2img.py
+++ b/tests/api_nodes/test_luma_img2img.py
@@ -1,0 +1,41 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../")))
+
+import pytest
+from PIL import Image
+from io import BytesIO
+import numpy as np
+
+from nodes.api_nodes.luma_img2img import LumaImg2Img
+
+
+@pytest.fixture
+def dummy_image():
+    return np.random.rand(3, 64, 64).astype(np.float32)
+
+def test_missing_api_key(monkeypatch, dummy_image):
+    monkeypatch.delenv("LUMA_API_KEY", raising=False)
+    node = LumaImg2Img()
+    with pytest.raises(Exception) as exc:
+        node.run(dummy_image, "cat prompt")
+    assert "LUMA_API_KEY" in str(exc.value)
+
+
+def test_successful_response(monkeypatch, mocker, dummy_image):
+    monkeypatch.setenv("LUMA_API_KEY", "test-key")
+
+    dummy_output = BytesIO()
+    img = Image.new("RGB", (64, 64), color="blue")
+    img.save(dummy_output, format="PNG")
+    dummy_output.seek(0)
+
+    mock_post = mocker.patch("nodes.api_nodes.luma_img2img.requests.post")
+    mock_post.return_value.ok = True
+    mock_post.return_value.content = dummy_output.getvalue()
+
+    node = LumaImg2Img()
+    result = node.run(dummy_image, "skyline prompt")
+
+    assert isinstance(result["image"], np.ndarray)
+    assert result["image"].shape == (3, 64, 64)


### PR DESCRIPTION
### Summary

This PR adds a `luma_img2img` node that connects to Luma's image-modify endpoint. It accepts an input image tensor and prompt, plus optional tuning parameters:

- `image_weight` (default 0.5)
- `model` (default "luma-v3")
- `aspect_ratio` (default "1:1")
- `seed` (optional)
- `timeout` (default 30s)

### Features

- Graceful failure with clear message if `$LUMA_API_KEY` is missing.
- Output is a valid image tensor usable by downstream nodes.
- Fully tested in `tests/api_nodes/test_luma_img2img.py` with HTTP mocking.

Let me know if you'd like any changes!