### PR TITLE
🎨 Add PixVerseStylize Node for Artistic Style Validation | OSS Challenge

### DIFF
--- a/ComfyUI/pixverse_stylize_node.py
+++ b/ComfyUI/pixverse_stylize_node.py
@@ -1,0 +1,23 @@
+from PIL import Image
+
+class PixVerseStylize:
+    NAME = "PixVerseStylize"
+
+    def __init__(self):
+        self.allowed_styles = [
+            "watercolor", "oil painting", "sketch", "manga", "cartoon",
+            "cyberpunk", "pixel art", "charcoal", "realism", "pop art",
+            "comic", "vintage", "pastel", "gothic", "anime", "steampunk",
+            "neon", "3d render", "graffiti", "low poly"
+        ]
+
+    def process(self, image: Image.Image, style: str) -> Image.Image:
+        if style not in self.allowed_styles:
+            raise ValueError(
+                f"Unsupported style '{style}'. Supported styles: {', '.join(self.allowed_styles)}"
+            )
+        return image  # Currently, it just returns the original image
+
+NODE_CLASS_MAPPINGS = {
+    "PixVerseStylize": PixVerseStylize
+}


### PR DESCRIPTION
### 📌 Summary

This PR introduces a new `PixVerseStylize` node under `ComfyUI`, developed as part of the DreamLayer OSS Challenge.

### ✨ Features

- Accepts a PNG image and a style string as input.
- Validates the style string against 20 preset styles (e.g., "watercolor", "cyberpunk", "sketch", etc.).
- Returns the input image as-is (for now) if the style is valid.
- Raises a clear and descriptive `ValueError` if the style is unsupported.
- Code is modular, clean, and ready for future style transformation logic.

### 🚀 Why This Matters

This node lays the foundation for integrating PixVerse-style transformations in DreamLayer and helps demonstrate real-world user input validation in UI-based pipelines.

### 🧪 Status

- ✅ Node file created: `pixverse_stylize_node.py`
- 🔲 Test file: (optional, can be added later)

---

Developed with ❤️ by Hareesh S
