### PR TITLE
Feature/recraft vectorize to save svg

### DIFF
--- a/ComfyUI/comfy_api_nodes/recraft_vectorize.py
+++ b/ComfyUI/comfy_api_nodes/recraft_vectorize.py
@@ -1,0 +1,119 @@
+# ComfyUI/comfy_api_nodes/recraft_vectorize.py
+import hashlib
+import os
+import torch
+import numpy as np
+from PIL import Image
+from comfy_api_nodes.nodes_recraft import handle_recraft_file_request
+
+from __future__ import annotations
+from inspect import cleandoc
+from typing import Optional
+from comfy.utils import ProgressBar
+from comfy_extras.nodes_images import SVG
+from comfy.comfy_types.node_typing import IO
+from comfy_api_nodes.apis.recraft_api import (
+    RecraftImageGenerationRequest,
+    RecraftImageGenerationResponse,
+    RecraftImageSize,
+    RecraftModel,
+    RecraftStyle,
+    RecraftStyleV3,
+    RecraftColor,
+    RecraftColorChain,
+    RecraftControls,
+    RecraftIO,
+    get_v3_substyles,
+)
+from comfy_api_nodes.apis.client import (
+    ApiEndpoint,
+    HttpMethod,
+    SynchronousOperation,
+    EmptyRequest,
+)
+from comfy_api_nodes.apinode_utils import (
+    bytesio_to_image_tensor,
+    download_url_to_bytesio,
+    tensor_to_bytesio,
+    resize_mask_to_image,
+    validate_string,
+)
+from server import PromptServer
+from io import BytesIO
+from PIL import UnidentifiedImageError
+
+class RecraftVectorizeNode:
+    """
+    Vectorizes a raster image using the Recraft API and saves it as a pure-vector SVG file.
+    """
+    RETURN_TYPES = ("STRING",)
+    DESCRIPTION = cleandoc(__doc__ or "") if 'cleandoc' in globals() else __doc__
+    RETURN_NAMES = ("svg_file_path",)
+    FUNCTION = "execute"
+    CATEGORY = "api node/image/Recraft"
+    API_NODE = True
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "image": (IO.IMAGE,),
+                "resolution_limit": (
+                    IO.INT, {
+                        "default": 2048, "min": 128, "max": 4096, "step": 64,
+                    }
+                ),
+                 "output_path": (
+                    IO.STRING, {
+                        "default": "output/vectorized_svgs",
+                        "tooltip": "Directory where the SVG files will be saved.",
+                    }
+                ),
+            },
+            "hidden": {
+                "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
+            },
+        }
+
+    def execute(self, image: torch.Tensor, resolution_limit: int, output_path: str, **kwargs) -> tuple[str]:
+        if image.shape[0] > 1:
+            print("Node handles images one by one. Processing the first image.")
+            image = image[0].unsqueeze(0)
+        pil_image = Image.fromarray(np.clip(255. * image.cpu().numpy().squeeze(), 0, 255).astype(np.uint8))
+        if pil_image.width > resolution_limit or pil_image.height > resolution_limit:
+            print(f"Image resolution ({pil_image.width}x{pil_image.height}) exceeds the recommended limit of {resolution_limit}px. This may result in longer processing times.")
+
+        # API Call to Recraft
+        print("Contacting Recraft API to vectorize image")
+        try:
+            # reusing handle_recraft_file_request function to send the image
+            svg_bytes_list = handle_recraft_file_request(
+                image=image,
+                path="/proxy/recraft/images/vectorize",
+                auth_kwargs=kwargs,
+            )
+            if not svg_bytes_list:
+                raise ConnectionError("The Recraft API did not return any data.")
+
+            svg_content = svg_bytes_list[0].getvalue().decode('utf-8')
+            print("Successfully received SVG data from API.")
+
+        except Exception as e:
+            print(f"Recraft API Error: {e}")
+            raise Exception(f"Failed to vectorize image. Reason: {e}") from e
+
+        # Save the SVG content to a file
+        image_hash = hashlib.sha256(pil_image.tobytes()).hexdigest()
+        filename = f"vectorized_{image_hash[:16]}.svg"
+
+        if not os.path.exists(output_path):
+            os.makedirs(output_path, exist_ok=True)
+
+        svg_file_path = os.path.join(output_path, filename)
+
+        with open(svg_file_path, "w", encoding="utf-8") as f:
+            f.write(svg_content)
+
+        print(f"SVG saved to: {svg_file_path}")
+        return (svg_file_path,)

--- a/ComfyUI/comfy_api_nodes/recraft_vectorize.py
+++ b/ComfyUI/comfy_api_nodes/recraft_vectorize.py
@@ -117,3 +117,12 @@ class RecraftVectorizeNode:
 
         print(f"SVG saved to: {svg_file_path}")
         return (svg_file_path,)
+    
+
+NODE_CLASS_MAPPINGS = {
+    "RecraftVectorizeNode": RecraftVectorizeNode,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "RecraftVectorizeNode": "Recraft Vectorize Image to File",
+}

--- a/ComfyUI/comfy_api_nodes/recraft_vectorize.py
+++ b/ComfyUI/comfy_api_nodes/recraft_vectorize.py
@@ -1,12 +1,10 @@
-# ComfyUI/comfy_api_nodes/recraft_vectorize.py
+from __future__ import annotations
 import hashlib
 import os
 import torch
 import numpy as np
 from PIL import Image
 from comfy_api_nodes.nodes_recraft import handle_recraft_file_request
-
-from __future__ import annotations
 from inspect import cleandoc
 from typing import Optional
 from comfy.utils import ProgressBar
@@ -84,7 +82,7 @@ class RecraftVectorizeNode:
         if pil_image.width > resolution_limit or pil_image.height > resolution_limit:
             print(f"Image resolution ({pil_image.width}x{pil_image.height}) exceeds the recommended limit of {resolution_limit}px. This may result in longer processing times.")
 
-        # API Call to Recraft
+        # API call to recraft
         print("Contacting Recraft API to vectorize image")
         try:
             # reusing handle_recraft_file_request function to send the image
@@ -103,7 +101,7 @@ class RecraftVectorizeNode:
             print(f"Recraft API Error: {e}")
             raise Exception(f"Failed to vectorize image. Reason: {e}") from e
 
-        # Save the SVG content to a file
+        # save SVG content to a file
         image_hash = hashlib.sha256(pil_image.tobytes()).hexdigest()
         filename = f"vectorized_{image_hash[:16]}.svg"
 

--- a/ComfyUI/tests-unit/comfy_api_nodes_test/test_recraft_vectorize.py
+++ b/ComfyUI/tests-unit/comfy_api_nodes_test/test_recraft_vectorize.py
@@ -1,0 +1,58 @@
+import unittest
+from unittest.mock import patch
+import torch
+import numpy as np
+import os
+import hashlib
+from io import BytesIO
+from comfy_api_nodes.recraft_vectorize import RecraftVectorizeNode
+
+class TestRecraftVectorizeNode(unittest.TestCase):
+    """
+    Unit test for the RecraftVectorizeNode.
+    """
+
+    def setUp(self):
+        """
+        Set up the environment for each test case.
+        """
+        self.node = RecraftVectorizeNode()
+        self.output_dir = "output/test_svgs"
+        # creating a dummy image for testing
+        dummy_array = np.zeros((64, 64, 3), dtype=np.uint8)
+        # gray square
+        dummy_array[16:48, 16:48, :] = 128 
+        self.image_tensor = torch.from_numpy(dummy_array.astype(np.float32) / 255.0).unsqueeze(0)
+        self.mock_svg_content = '<svg width="64" height="64"><rect x="16" y="16" width="32" height="32" fill="#808080"/></svg>'
+
+    def tearDown(self):
+        """
+        Clean up any files or directories created during tests.
+        """
+        if os.path.exists(self.output_dir):
+            for f in os.listdir(self.output_dir):
+                os.remove(os.path.join(self.output_dir, f))
+            os.rmdir(self.output_dir)
+
+    @patch('comfy_api_nodes.recraft_vectorize.handle_recraft_file_request')
+    def test_execute_saves_file_with_correct_checksum(self, mock_api_call):
+        mock_api_call.return_value = [BytesIO(self.mock_svg_content.encode('utf-8'))]
+
+        # executing the node
+        result_path, = self.node.execute(
+            image=self.image_tensor,
+            resolution_limit=1024,
+            output_path=self.output_dir,
+            auth_token="test_token"
+        )
+
+        mock_api_call.assert_called_once()
+
+        # verifications
+        self.assertEqual(mock_api_call.call_args[1]['path'], "/proxy/recraft/images/vectorize")
+        self.assertTrue(os.path.exists(result_path))
+        self.assertEqual(os.path.getsize(result_path), len(self.mock_svg_content.encode('utf-8')))
+        with open(result_path, 'rb') as f:
+            checksum = hashlib.sha256(f.read(1024)).hexdigest()
+        expected_checksum = hashlib.sha256(self.mock_svg_content.encode('utf-8')).hexdigest()
+        self.assertEqual(checksum, expected_checksum)


### PR DESCRIPTION
## Description
feature: Add SVG vectorization node
Introduces a new, self-contained RecraftVectorizeNode for converting raster images into pure-vector SVG files and saving them directly to the filesystem.

## Changes Made
The node saves the generated SVG directly to the filesystem and returns the file path. Implemented a new unit test that verifies file size. Add a resolution_limit parameter to proactively warn users about performance with high-resolution images.

## Evidence Required ✅

### Tests (Optional)
#### Testing
Add Unit Test for Vectorization: A new unit test file (test_recraft_vectorize.py) has been added to the tests-unit/comfy_api_nodes_test/ suite.
Mocked API and Checksum Verification: The test uses a mocked API response to validate the node's logic in isolation. It rigorously verifies that the output file is created with the correct content, confirming the node's deterministic behavior.

========================================================================== test session starts ==========================================================================
platform darwin -- Python 3.12.7, pytest-8.4.1, pluggy-1.5.0
rootdir: /Users/riyazshaik/Documents/DreamLayer/ComfyUI
configfile: pytest.ini
plugins: time-machine-2.16.0, langsmith-0.4.4, dash-3.0.2, anyio-4.2.0, asyncio-1.0.0, aiohttp-1.1.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 143 items                                                                                                                                                     

tests-unit/app_test/custom_node_manager_test.py .....
tests-unit/app_test/frontend_manager_test.py ...........
tests-unit/app_test/model_manager_test.py .
tests-unit/comfy_api_nodes_test/mapper_utils_test.py ............
tests-unit/comfy_api_nodes_test/test_recraft_vectorize.py Contacting Recraft API to vectorize image
Successfully received SVG data from API.
SVG saved to: output/test_svgs/vectorized_84fa4f27c92bd2f6.svg
.
tests-unit/comfy_api_test/input_impl_test.py .........
tests-unit/comfy_api_test/video_types_test.py ...............
tests-unit/comfy_extras_test/image_stitch_test.py ...................
tests-unit/comfy_test/folder_path_test.py .............
tests-unit/execution_test/validate_node_input_test.py ...............
tests-unit/folder_paths_test/filter_by_content_types_test.py .....
tests-unit/prompt_server_test/user_manager_test.py ...................
tests-unit/server/utils/file_operations_test.py ...
tests-unit/utils/extra_config_test.py .....
tests-unit/utils/json_util_test.py ..........

========================================================================== 143 passed in 4.46s ==========================================================================

## Checklist
- [ ] Tests added (optional)
- [ ] Code follows project style
- [ ] Self-review completed 