### PR TITLE
Create test_debug_reproduce.py

### DIFF
--- a/test_debug_reproduce.py
+++ b/test_debug_reproduce.py
@@ -28,7 +28,6 @@ def setup_job(tmp_path):
         f.write(output_bytes)
 
     # Save last job record
-    JOBS_DIR.mkdir(parents=True, exist_ok=True)
     LAST_JOB_FILE.write_text(json.dumps({
         "input_path": str(input_image),
         "output_path": str(output_image),


### PR DESCRIPTION
## Description
A pytest that submits a dummy job, mutates the image, calls /debug/reproduce, and expects false.

## Summary by Sourcery

Add a pytest suite to verify the /debug/reproduce endpoint correctly detects image mismatches and handles missing job records

Tests:
- Add fixture to generate a dummy job and mutated output image with a last job JSON record
- Test that /debug/reproduce returns match=false when the output image is altered
- Test that /debug/reproduce returns a 404 and appropriate error when no last job record exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests to verify that the `/debug/reproduce` endpoint correctly detects image mismatches and handles missing job data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->