### PR TITLE
feat: add graph viewer to render ComfyUI JSON using react-flow

### DIFF
--- a/dream_layer_frontend/src/App.tsx
+++ b/dream_layer_frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import GraphViewer from "./pages/GraphViewer";
 
 const queryClient = new QueryClient();
 
@@ -17,6 +18,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/graph" element={<GraphViewer />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/dream_layer_frontend/src/assets/sample-graph.json
+++ b/dream_layer_frontend/src/assets/sample-graph.json
@@ -1,0 +1,14 @@
+{
+  "nodes": {
+    "1": {
+      "class_type": "TextPrompt",
+      "inputs": {}
+    },
+    "2": {
+      "class_type": "ImageGen",
+      "inputs": {
+        "prompt": [["1", 0]]
+      }
+    }
+  }
+}

--- a/dream_layer_frontend/src/pages/GraphViewer.tsx
+++ b/dream_layer_frontend/src/pages/GraphViewer.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import ReactFlow, { Background, Controls, MiniMap } from "react-flow-renderer";
+import graphData from "../assets/sample-graph.json";
+
+const GraphViewer = () => {
+  const [nodes, setNodes] = useState<any[]>([]);
+  const [edges, setEdges] = useState<any[]>([]);
+
+
+  useEffect(() => {
+    const nodes: any[] = [];
+    const edges: any[] = [];
+
+    Object.entries(graphData.nodes).forEach(([id, node]: any, index) => {
+      nodes.push({
+        id,
+        data: { label: node.class_type },
+        position: { x: index * 200, y: index * 100 },
+      });
+
+      if (node.inputs) {
+        Object.values(node.inputs).forEach((inputArr: any) => {
+          inputArr.forEach((ref: any) => {
+            const [sourceId] = ref;
+            edges.push({
+              id: `${sourceId}-${id}`,
+              source: sourceId,
+              target: id,
+            });
+          });
+        });
+      }
+    });
+
+    setNodes(nodes);
+    setEdges(edges);
+
+  }, []);
+
+  return (
+    <div style={{ height: "100vh" }}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        zoomOnScroll={false}
+        panOnScroll={true}
+      >
+        <MiniMap />
+        <Controls />
+        <Background />
+      </ReactFlow>
+    </div>
+  );
+};
+
+export default GraphViewer;


### PR DESCRIPTION
## Summary

This PR adds a new frontend route `/graph` that renders a ComfyUI-style JSON workflow as a read-only node graph using `react-flow`.

## Features

- Parses static JSON from `src/assets/sample-graph.json`
- Displays each node with its `class_type`
- Draws connections (edges) based on node inputs
- Uses `react-flow` for layout and interaction
- No model selection or backend dependency
- Accessible at: http://localhost:8080/graph

## Screenshot

<img width="959" height="530" alt="image" src="https://github.com/user-attachments/assets/eea2d4ec-55dd-46c3-a803-ed4ffc24b3ff" />

## Task

Frontend Challenge: Read ComfyUI JSON & render a read-only SVG node map via react-flow.

## Summary by Sourcery

Add a new GraphViewer page that renders a static ComfyUI JSON workflow as a read-only node graph using react-flow at the "/graph" route

New Features:
- Add GraphViewer component to parse and display nodes and edges from sample-graph.json
- Register "/graph" route in App to expose the graph viewer
- Integrate react-flow with MiniMap, Controls, and Background for interactive read-only visualization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "/graph" route that displays a visual graph viewer.
  * Introduced a graph visualization page that loads and displays a sample graph structure.
  * Users can interact with the graph viewer, featuring panning, a minimap, controls, and a background grid for improved navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->